### PR TITLE
raw-data: add raw data screen to sessions overview tab

### DIFF
--- a/src/views/SessionOverview.js
+++ b/src/views/SessionOverview.js
@@ -1,5 +1,6 @@
 import React from "react";
 import SwingReplay from "./SwingReplay";
+import ChartistGraph from "react-chartist";
 
 // react-bootstrap components
 import {
@@ -26,11 +27,150 @@ const swingReplayCard = (
 );
 
 const rawCard = (
-  <Card>
-    <Card.Header>
-      <Card.Title as="h4">Raw Data</Card.Title>
-    </Card.Header>
-  </Card>
+<Container fluid>
+  <Row>
+    <Col lg="4" sm="6">
+      <Card className="card-stats">
+        <Card.Body>
+          <Row>
+            <Col xs="5">
+              <div className="icon-big text-center icon-warning">
+                <i className="nc-icon nc-chart text-warning"></i>
+              </div>
+            </Col>
+            <Col xs="7">
+              <div className="numbers">
+                <p className="card-category">Total Swings</p>
+                <Card.Title as="h4">33</Card.Title>
+              </div>
+            </Col>
+          </Row>
+        </Card.Body>
+      </Card>
+    </Col>
+    <Col lg="4" sm="6">
+      <Card className="card-stats">
+        <Card.Body>
+          <Row>
+            <Col xs="5">
+              <div className="icon-big text-center icon-warning">
+                <i className="nc-icon nc-spaceship text-danger"></i>
+              </div>
+            </Col>
+            <Col xs="7">
+              <div className="numbers">
+                <p className="card-category">Average Ball Distance</p>
+                <Card.Title as="h4">55,6 Meters</Card.Title>
+              </div>
+            </Col>
+          </Row>
+        </Card.Body>
+      </Card>
+    </Col>
+    <Col lg="4" sm="6">
+      <Card className="card-stats">
+        <Card.Body>
+          <Row>
+            <Col xs="5">
+              <div className="icon-big text-center icon-warning">
+                <i className="nc-icon nc-zoom-split text-primary"></i>
+              </div>
+            </Col>
+            <Col xs="7">
+              <div className="numbers">
+                <p className="card-category">Average Ball Speed</p>
+                <Card.Title as="h4">215 km/h</Card.Title>
+              </div>
+            </Col>
+          </Row>
+        </Card.Body>
+      </Card>
+    </Col>
+  </Row>
+  <Row>
+    <Col lg="4" sm="12" xs="12">
+      <Card>
+        <Card.Header>
+          <Card.Title as="h4">Swing Results</Card.Title>
+          <p className="card-category">Ending location of golf ball</p>
+        </Card.Header>
+          <Card.Body>
+            <div className="ct-chart" id="chartHours">
+              <ChartistGraph
+                data={{
+                  series: [{
+                    value: 17,
+                    name: "Fairway"
+                  },
+                  {
+                    value: 9,
+                    name: "Off Fairway"
+                  },
+                  {
+                    value: 4,
+                    name: "Sand Pit"
+                  },
+                  {
+                    value: 3,
+                    name: "Water"
+                  }],
+                }}
+                type="Pie"
+                options={{
+                  donut: false
+                }}
+              />
+            </div>
+          </Card.Body>
+          <Card.Footer>
+            <hr></hr>
+            <div className="legend">
+              <i className="fas fa-circle text-info"></i>
+              Fairway <i className="fas fa-circle text-danger"></i>
+              Off Fairway <i className="fas fa-circle text-warning"></i>
+              Sand Pit <i className="fas fa-circle" style={{ color: "#9368E9", fill: "#9368E9" }}></i>
+              Water
+            </div>
+          </Card.Footer>
+      </Card>
+    </Col>
+    <Col lg="8" sm="12" xs="12">
+      <Card>
+        <Card.Header>
+          <Card.Title as="h4">Shot Spin</Card.Title>
+          <p className="card-category">Direction the ball spinned midflight</p>
+        </Card.Header>
+          <Card.Body>
+            <div className="ct-chart" id="chartHours">
+              <ChartistGraph
+                data={{
+                  labels: ["No Spin", "Left Spin", "Right Spin", "Backspin"],
+                  series: [[12, 15, 5, 1]],
+                }}
+                type="Bar"
+                options={{
+                  high: 20,
+                  low: 0
+                }}
+              />
+            </div>
+          </Card.Body>
+          <Card.Footer>
+            <hr></hr>
+            <div className="legend">
+              <i className="fas fa-circle text-info"></i>
+              Mike
+            </div>
+            <div style={{ float: "right", paddingTop: "5px" }}>
+              <a href="#">
+                + Add Users to Compare
+              </a>
+            </div>
+          </Card.Footer>
+      </Card>
+    </Col>
+  </Row>
+</Container>
 );
 
 /**


### PR DESCRIPTION
- [x]  Add data graphs to the "Raw Data" tab in `/sessions/overview`
<img width="1440" alt="Screen Shot 2022-03-15 at 5 02 26 PM" src="https://user-images.githubusercontent.com/19559133/158421296-81a71170-7b6b-4f15-a6f4-78ff664d1e8d.png">

